### PR TITLE
config.exs API KEY from environment variable

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,8 +10,8 @@
 import Config
 
 config :binance,
-  api_key: "YOUR-API-KEY-HERE",
-  secret_key: "YOUR-SECRET-KEY-HERE"
+  api_key: System.get_env("BINANCE_API_KEY"),
+  secret_key: System.get_env("BINANCE_SECRET_KEY")
 
 config :logger,
   level: :info


### PR DESCRIPTION
To avoid adding the API KEY to the code.

This is only a suggestion, maybe this is not necessary for the objective of the book.