### PR TITLE
leader.ex, error case shows reason

### DIFF
--- a/apps/naive/lib/naive/leader.ex
+++ b/apps/naive/lib/naive/leader.ex
@@ -94,10 +94,10 @@ defmodule Naive.Leader do
   end
 
   def handle_info(
-        {:DOWN, _ref, :process, trader_pid, _reason},
+        {:DOWN, _ref, :process, trader_pid, reason},
         %{traders: traders, symbol: symbol} = state
       ) do
-    Logger.error("#{symbol} trader died - trying to restart")
+    Logger.error("#{symbol} trader died - reason #{reason} - trying to restart")
 
     case Enum.find_index(traders, &(&1.pid == trader_pid)) do
       nil ->


### PR DESCRIPTION
It could be used to identify a problem in an unexpected finishing case.

For me, it was useful to identify a typo when I was trying the code.