### PR TITLE
leader.ex, budget with from_float

### DIFF
--- a/apps/naive/lib/naive/leader.ex
+++ b/apps/naive/lib/naive/leader.ex
@@ -121,7 +121,7 @@ defmodule Naive.Leader do
   defp fresh_trader_state(settings) do
     %{
       struct(Trader.State, settings) |
-      budget: D.div(settings.budget, settings.chunks)
+      budget: D.div(D.from_float(settings.budget), D.from_float(settings.chunks))
     }
   end
 


### PR DESCRIPTION
To try to avoid this error.

```
[error] GenServer :"Elixir.Naive.Leader-ETHBTC" terminating
** (ArgumentError) implicit conversion of 0.003 to Decimal is not allowed. Use Decimal.from_float/1
    (decimal 2.0.0) lib/decimal.ex:1734: Decimal.decimal/1
    (decimal 2.0.0) lib/decimal.ex:472: Decimal.div/2
    (naive 0.1.0) lib/naive/leader.ex:157: Naive.Leader.fresh_trader_state/1
    (naive 0.1.0) lib/naive/leader.ex:54: Naive.Leader.handle_continue/2
    (stdlib 3.15.1) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.15.1) gen_server.erl:437: :gen_server.loop/7
    (stdlib 3.15.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: {:continue, :start_traders}
State: %Naive.Leader.State{settings: nil, symbol: "ETHBTC", traders: []}
```

When your budget is in bitcoins your budget could be float.